### PR TITLE
fix: removed context on parsing actions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jankenstore"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["Martin Zheng <jszhengyq@gmail.com>"]
 description = "Database operation helpers library"

--- a/release.md
+++ b/release.md
@@ -1,2 +1,1 @@
--   Removed unnecessary entities: commands
--   Added `ParsableOp` for actions so it's easier to use together with JSON strings
+-   Removed unnecessary context on action parsing

--- a/src/action/payload.rs
+++ b/src/action/payload.rs
@@ -1,6 +1,5 @@
 use std::{collections::HashMap, fmt::Debug};
 
-use anyhow::Context;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
@@ -36,8 +35,7 @@ pub trait ParsableOp<'a>: Debug + Serialize + Deserialize<'a> {
     /// # Arguments
     /// * `cmd` - The string to parse, it must be a valid JSON string
     fn from_str(cmd: &'a str) -> anyhow::Result<Self> {
-        let op: Self = serde_json::from_str(cmd)
-            .with_context(|| format!("Failed to parse an action op from string: {}", cmd))?;
+        let op: Self = serde_json::from_str(cmd)?;
         Ok(op)
     }
 }

--- a/tests/snapshots/test_input_errors_create__parsing_errors-2.snap
+++ b/tests/snapshots/test_input_errors_create__parsing_errors-2.snap
@@ -2,4 +2,4 @@
 source: tests/test_input_errors_create.rs
 expression: result.unwrap_err()
 ---
-EOF while parsing an object at line 1 column 23
+unknown variant `BadOp`, expected `Create` or `CreateChild` at line 1 column 9

--- a/tests/test_input_errors_create.rs
+++ b/tests/test_input_errors_create.rs
@@ -25,6 +25,10 @@ fn test_parsing_errors() -> Result<()> {
     assert!(result.is_err());
     assert_snapshot!(result.unwrap_err());
 
+    let result = CreateOp::from_str(r#"{ "BadOp": ["song", 1] }"#);
+    assert!(result.is_err());
+    assert_snapshot!(result.unwrap_err());
+
     Ok(())
 }
 


### PR DESCRIPTION
Since the context will unnecessarily blocks debugging message underneath